### PR TITLE
Add distance bucket labels and unit conversions

### DIFF
--- a/shared/src/commonMain/kotlin/com/mebeatme/shared/core/ChallengeGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mebeatme/shared/core/ChallengeGenerator.kt
@@ -79,7 +79,7 @@ class ChallengeGenerator(
         return ChallengeOption(
             id = "short_fierce_${System.currentTimeMillis()}",
             title = "Short & Fierce",
-            description = "Hold ${PaceUtils.formatPace(targetPace)}/km for ${formatDuration(targetDuration)} to top your best ${bucket.name.lowercase()} equivalent",
+            description = "Hold ${PaceUtils.formatPace(targetPace)}/km for ${formatDuration(targetDuration)} to top your best ${bucket.label.lowercase()} equivalent",
             targetPace = targetPace,
             targetDuration = targetDuration,
             targetDistance = targetDistance,

--- a/shared/src/commonMain/kotlin/com/mebeatme/shared/core/PurdyPointsCalculator.kt
+++ b/shared/src/commonMain/kotlin/com/mebeatme/shared/core/PurdyPointsCalculator.kt
@@ -94,9 +94,21 @@ object PurdyPointsCalculator {
  * Utility functions for pace and time conversions
  */
 object PaceUtils {
-    
+
+    fun metersPerSecondToSecondsPerKm(metersPerSecond: Double): Double =
+        if (metersPerSecond == 0.0) Double.POSITIVE_INFINITY else 1000.0 / metersPerSecond
+
+    fun secondsPerKmToMetersPerSecond(secondsPerKm: Double): Double =
+        if (secondsPerKm == 0.0) 0.0 else 1000.0 / secondsPerKm
+
+    fun metersPerSecondToMinutesPerKm(metersPerSecond: Double): Double =
+        secondsPerKmToMinutesPerKm(metersPerSecondToSecondsPerKm(metersPerSecond))
+
+    fun minutesPerKmToMetersPerSecond(minutesPerKm: Double): Double =
+        secondsPerKmToMetersPerSecond(minutesPerKmToSecondsPerKm(minutesPerKm))
+
     fun secondsPerKmToMinutesPerKm(secondsPerKm: Double): Double = secondsPerKm / 60.0
-    
+
     fun minutesPerKmToSecondsPerKm(minutesPerKm: Double): Double = minutesPerKm * 60.0
     
     fun formatPace(secondsPerKm: Double): String {

--- a/shared/src/commonMain/kotlin/com/mebeatme/shared/model/DataModels.kt
+++ b/shared/src/commonMain/kotlin/com/mebeatme/shared/model/DataModels.kt
@@ -30,15 +30,19 @@ data class Score(
 )
 
 @Serializable
-enum class DistanceBucket(val minKm: Double, val maxKm: Double) {
-    SHORT_SPRINT(0.0, 1.0),
-    SPRINT(1.0, 3.0),
-    SHORT_RUN(3.0, 8.0),
-    MEDIUM_RUN(8.0, 15.0),
-    LONG_RUN(15.0, 25.0),
-    ULTRA_RUN(25.0, Double.MAX_VALUE);
-    
+enum class DistanceBucket(val minKm: Double, val maxKm: Double, val label: String) {
+    SHORT_SPRINT(0.0, 1.0, "Short sprint"),
+    SPRINT(1.0, 3.0, "Sprint"),
+    SHORT_RUN(3.0, 8.0, "Short run"),
+    MEDIUM_RUN(8.0, 15.0, "Medium run"),
+    LONG_RUN(15.0, 25.0, "Long run"),
+    ULTRA_RUN(25.0, Double.MAX_VALUE, "Ultra run");
+
     fun contains(distanceKm: Double): Boolean = distanceKm >= minKm && distanceKm < maxKm
+
+    companion object {
+        fun fromLabel(label: String): DistanceBucket? = values().find { it.label.equals(label, ignoreCase = true) }
+    }
 }
 
 @Serializable

--- a/shared/src/commonTest/kotlin/com/mebeatme/shared/core/CoreTests.kt
+++ b/shared/src/commonTest/kotlin/com/mebeatme/shared/core/CoreTests.kt
@@ -204,7 +204,32 @@ class PaceUtilsTest {
         val secondsPerKm = 300.0
         val minutesPerKm = PaceUtils.secondsPerKmToMinutesPerKm(secondsPerKm)
         val backToSeconds = PaceUtils.minutesPerKmToSecondsPerKm(minutesPerKm)
-        
+
         assertEquals(secondsPerKm, backToSeconds, "Conversion should be reversible")
+    }
+
+    @Test
+    fun testSpeedConversions() {
+        val mps = 5.0
+        val secPerKm = PaceUtils.metersPerSecondToSecondsPerKm(mps)
+        assertEquals(200.0, secPerKm, 0.0001, "5 m/s should be 200 sec/km")
+        val backToMps = PaceUtils.secondsPerKmToMetersPerSecond(secPerKm)
+        assertEquals(mps, backToMps, 0.0001, "Conversion should be reversible")
+        val minPerKm = PaceUtils.metersPerSecondToMinutesPerKm(mps)
+        assertEquals(200.0 / 60.0, minPerKm, 0.0001, "5 m/s should be 3.333... min/km")
+        val mpsAgain = PaceUtils.minutesPerKmToMetersPerSecond(minPerKm)
+        assertEquals(mps, mpsAgain, 0.0001, "Conversion should be reversible")
+    }
+}
+
+class DistanceBucketLabelTest {
+
+    @Test
+    fun testLabelRoundTrip() {
+        DistanceBucket.values().forEach { bucket ->
+            val label = bucket.label
+            val parsed = DistanceBucket.fromLabel(label)
+            assertEquals(bucket, parsed, "Label should map back to original bucket")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add human-readable labels and lookup for `DistanceBucket`
- centralize pace/speed conversions in `PaceUtils`
- update challenge generation to use bucket labels
- cover conversions and labels with new tests

## Testing
- `gradle :shared:check :core:check` *(fails: Plugin [id: 'com.android.application', version: '8.6.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a353d688321b4068599bdf1888b