### PR TITLE
Add Android app skeleton with GPX import and PPI analysis

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+    kotlin("plugin.serialization")
+}
+
+android {
+    namespace = "com.mebeatme.android"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.mebeatme.android"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.1"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    buildFeatures { compose = true }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.3" }
+    packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
+}
+
+dependencies {
+    implementation(project(":shared"))
+    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.navigation:navigation-compose:2.7.5")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mebeatme.android">
+    <application android:label="MeBeatMe">
+        <activity android:name="com.mebeatme.android.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/androidApp/src/main/java/com/mebeatme/android/App.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/App.kt
@@ -1,0 +1,29 @@
+package com.mebeatme.android
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { App() }
+    }
+}
+
+@Composable
+fun App() {
+    val nav = rememberNavController()
+    MaterialTheme {
+        NavHost(navController = nav, startDestination = "home") {
+            composable("home") { /* TODO HomeScreen */ }
+            composable("import") { /* TODO ImportScreen */ }
+            composable("settings") { /* TODO SettingsScreen */ }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/data/import/FileImportCoordinator.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/data/import/FileImportCoordinator.kt
@@ -1,0 +1,21 @@
+package com.mebeatme.android.data.import
+
+import android.content.ContentResolver
+import android.net.Uri
+import com.mebeatme.android.data.import.parsers.GPXParser
+import com.mebeatme.android.models.RunRecord
+
+class FileImportCoordinator(
+    private val gpxParser: GPXParser = GPXParser()
+) {
+    suspend fun import(uri: Uri, resolver: ContentResolver): RunRecord {
+        val ext = uri.lastPathSegment?.substringAfterLast('.')?.lowercase()
+        resolver.openInputStream(uri)?.use { input ->
+            return when (ext) {
+                "gpx" -> gpxParser.parse(input)
+                else -> error("Unsupported file type: $ext")
+            }
+        }
+        error("Unable to open input stream for $uri")
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/data/import/parsers/GPXParser.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/data/import/parsers/GPXParser.kt
@@ -1,0 +1,63 @@
+package com.mebeatme.android.data.import.parsers
+
+import com.mebeatme.android.models.RunRecord
+import java.io.InputStream
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.math.*
+
+class GPXParser {
+    fun parse(input: InputStream): RunRecord {
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(input)
+        val points = doc.getElementsByTagName("trkpt")
+        var lastLat = 0.0
+        var lastLon = 0.0
+        var total = 0.0
+        var startTime: Long? = null
+        var endTime: Long? = null
+        for (i in 0 until points.length) {
+            val node = points.item(i)
+            val lat = node.attributes.getNamedItem("lat").nodeValue.toDouble()
+            val lon = node.attributes.getNamedItem("lon").nodeValue.toDouble()
+            val timeNode = node.childNodes
+            var timeStr: String? = null
+            for (j in 0 until timeNode.length) {
+                val c = timeNode.item(j)
+                if (c.nodeName == "time") {
+                    timeStr = c.textContent
+                    break
+                }
+            }
+            val time = timeStr?.let { Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(it)).toEpochMilli() }
+            if (startTime == null) startTime = time
+            if (time != null) endTime = time
+            if (i > 0) {
+                total += haversine(lastLat, lastLon, lat, lon)
+            }
+            lastLat = lat
+            lastLon = lon
+        }
+        val elapsedSec = ((endTime ?: 0) - (startTime ?: 0)) / 1000
+        val pace = if (total > 0) elapsedSec.toDouble() / (total / 1000.0) else 0.0
+        return RunRecord(
+            id = UUID.randomUUID().toString(),
+            source = "GPX",
+            startedAtEpochMs = startTime ?: 0,
+            endedAtEpochMs = endTime ?: 0,
+            distanceMeters = total,
+            elapsedSeconds = elapsedSec.toInt(),
+            avgPaceSecPerKm = pace
+        )
+    }
+
+    private fun haversine(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        val R = 6371000.0
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+        val a = sin(dLat / 2).pow(2.0) + cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(dLon / 2).pow(2.0)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return R * c
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/data/import/parsers/TCXParser.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/data/import/parsers/TCXParser.kt
@@ -1,0 +1,4 @@
+package com.mebeatme.android.data.import.parsers
+
+// TODO: Implement TCX parsing
+class TCXParser

--- a/androidApp/src/main/java/com/mebeatme/android/data/persistence/RunStore.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/data/persistence/RunStore.kt
@@ -1,0 +1,53 @@
+package com.mebeatme.android.data.persistence
+
+import com.mebeatme.android.models.Bests
+import com.mebeatme.android.models.RunRecord
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import java.io.File
+import kotlin.math.max
+
+interface RunStore {
+    suspend fun save(run: RunRecord)
+    suspend fun list(limit: Int? = null): List<RunRecord>
+    suspend fun bests(nowMs: Long = System.currentTimeMillis()): Bests
+    suspend fun clear()
+}
+
+class JsonRunStore(
+    private val file: File,
+    private val json: Json = Json { encodeDefaults = true; prettyPrint = true }
+) : RunStore {
+    override suspend fun save(run: RunRecord) = withContext(Dispatchers.IO) {
+        val runs = list().toMutableList()
+        runs += run
+        writeRuns(runs)
+    }
+
+    override suspend fun list(limit: Int?): List<RunRecord> = withContext(Dispatchers.IO) {
+        if (!file.exists()) return@withContext emptyList()
+        val text = file.readText()
+        val runs = if (text.isBlank()) emptyList() else json.decodeFromString(ListSerializer(RunRecord.serializer()), text)
+        return@withContext if (limit != null) runs.takeLast(limit) else runs
+    }
+
+    override suspend fun bests(nowMs: Long): Bests = withContext(Dispatchers.IO) {
+        val runs = list()
+        val window = nowMs - 90L * 24 * 60 * 60 * 1000
+        val highest = runs.filter { it.startedAtEpochMs >= window }.maxOfOrNull { it.ppi ?: Double.MIN_VALUE }
+        Bests(highestPPILast90Days = if (highest == Double.MIN_VALUE) null else highest)
+    }
+
+    override suspend fun clear() = withContext(Dispatchers.IO) {
+        if (file.exists()) file.delete()
+    }
+
+    private fun writeRuns(runs: List<RunRecord>) {
+        val tmp = File(file.parentFile, file.name + ".tmp")
+        tmp.writeText(json.encodeToString(ListSerializer(RunRecord.serializer()), runs))
+        if (file.exists()) file.delete()
+        tmp.renameTo(file)
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/domain/AnalysisService.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/domain/AnalysisService.kt
@@ -1,0 +1,19 @@
+package com.mebeatme.android.domain
+
+import com.mebeatme.android.models.RunRecord
+import kotlin.math.max
+
+class AnalysisService(
+    private val perf: PerfIndex = PerfIndex
+) {
+    fun analyze(run: RunRecord, windowSec: Int = 60 * 60 * 24 * 7 * 8): Pair<RunRecord, Recommendation> {
+        val ppi = perf.purdyScore(run.distanceMeters, run.elapsedSeconds)
+        val targetPace = perf.targetPace(run.distanceMeters, windowSec)
+        val rec = Recommendation(
+            targetPaceSecPerKm = targetPace,
+            projectedGainPPI = max(0.0, targetPace - run.avgPaceSecPerKm),
+            notes = "Aim for ~%.1f s/km over %d weeks.".format(targetPace, windowSec / 604800)
+        )
+        return run.copy(ppi = ppi) to rec
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/domain/KmpBridge.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/domain/KmpBridge.kt
@@ -1,0 +1,11 @@
+package com.mebeatme.android.domain
+
+import com.mebeatme.shared.core.PurdyPointsCalculator
+
+object PerfIndex {
+    fun purdyScore(distanceMeters: Double, durationSec: Int): Double =
+        PurdyPointsCalculator.calculatePPI(distanceMeters, durationSec.toLong())
+
+    fun targetPace(distanceMeters: Double, windowSec: Int): Double =
+        PurdyPointsCalculator.calculateRequiredPace(distanceMeters, 1000.0)
+}

--- a/androidApp/src/main/java/com/mebeatme/android/domain/Recommendation.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/domain/Recommendation.kt
@@ -1,0 +1,7 @@
+package com.mebeatme.android.domain
+
+data class Recommendation(
+    val targetPaceSecPerKm: Double,
+    val projectedGainPPI: Double,
+    val notes: String
+)

--- a/androidApp/src/main/java/com/mebeatme/android/models/Bests.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/models/Bests.kt
@@ -1,0 +1,12 @@
+package com.mebeatme.android.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Bests(
+    val best5kSec: Int? = null,
+    val best10kSec: Int? = null,
+    val bestHalfSec: Int? = null,
+    val bestFullSec: Int? = null,
+    val highestPPILast90Days: Double? = null
+)

--- a/androidApp/src/main/java/com/mebeatme/android/models/RunRecord.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/models/RunRecord.kt
@@ -1,0 +1,17 @@
+package com.mebeatme.android.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RunRecord(
+    val id: String,
+    val source: String,
+    val startedAtEpochMs: Long,
+    val endedAtEpochMs: Long,
+    val distanceMeters: Double,
+    val elapsedSeconds: Int,
+    val avgPaceSecPerKm: Double,
+    val avgHr: Int? = null,
+    val ppi: Double? = null,
+    val notes: String? = null
+)

--- a/androidApp/src/main/java/com/mebeatme/android/models/Split.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/models/Split.kt
@@ -1,0 +1,11 @@
+package com.mebeatme.android.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Split(
+    val index: Int,
+    val distanceMeters: Double,
+    val elapsedSeconds: Int,
+    val avgHr: Int? = null
+)

--- a/androidApp/src/main/java/com/mebeatme/android/ui/analysis/AnalysisScreen.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/analysis/AnalysisScreen.kt
@@ -1,0 +1,15 @@
+package com.mebeatme.android.ui.analysis
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.mebeatme.android.domain.Recommendation
+
+@Composable
+fun AnalysisScreen(rec: Recommendation) {
+    Column {
+        Text("Target pace: ${"%.1f".format(rec.targetPaceSecPerKm)} s/km")
+        Text("Projected gain: ${"%.1f".format(rec.projectedGainPPI)}")
+        Text(rec.notes)
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/ui/detail/RunDetailScreen.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/detail/RunDetailScreen.kt
@@ -1,0 +1,15 @@
+package com.mebeatme.android.ui.detail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.mebeatme.android.models.RunRecord
+
+@Composable
+fun RunDetailScreen(run: RunRecord) {
+    Column {
+        Text("Distance: ${run.distanceMeters}")
+        Text("Elapsed: ${run.elapsedSeconds}s")
+        Text("PPI: ${run.ppi ?: "--"}")
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/ui/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/home/HomeScreen.kt
@@ -1,0 +1,30 @@
+package com.mebeatme.android.ui.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.clickable
+import com.mebeatme.android.models.RunRecord
+
+@Composable
+fun HomeScreen(viewModel: HomeViewModel, onImport: () -> Unit, onRun: (RunRecord) -> Unit) {
+    val runs by viewModel.runs.collectAsState()
+    val highest by viewModel.highestPPILast90Days.collectAsState()
+    LaunchedEffect(Unit) { viewModel.load() }
+    Scaffold(floatingActionButton = { FloatingActionButton(onClick = onImport) { Text("+") } }) { _ ->
+        Column(Modifier.fillMaxSize()) {
+            Text("Highest PPI (90 days): ${highest ?: "--"}")
+            LazyColumn {
+                items(runs) { run ->
+                    ListItem(headlineText = { Text(run.distanceMeters.toInt().toString() + " m") },
+                        supportingText = { Text("Pace ${"%.1f".format(run.avgPaceSecPerKm)} s/km") },
+                        modifier = Modifier.clickable { onRun(run) })
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/ui/home/HomeViewModel.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/home/HomeViewModel.kt
@@ -1,0 +1,23 @@
+package com.mebeatme.android.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mebeatme.android.data.persistence.RunStore
+import com.mebeatme.android.models.RunRecord
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class HomeViewModel(private val store: RunStore) : ViewModel() {
+    private val _runs = MutableStateFlow<List<RunRecord>>(emptyList())
+    val runs: StateFlow<List<RunRecord>> = _runs
+    private val _highest = MutableStateFlow<Double?>(null)
+    val highestPPILast90Days: StateFlow<Double?> = _highest
+
+    fun load() {
+        viewModelScope.launch {
+            _runs.value = store.list(20)
+            _highest.value = store.bests().highestPPILast90Days
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/ui/import/ImportScreen.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/import/ImportScreen.kt
@@ -1,0 +1,15 @@
+package com.mebeatme.android.ui.import
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+
+@Composable
+fun ImportScreen(viewModel: ImportViewModel, onPick: () -> Unit) {
+    val importing by viewModel.importing.collectAsState()
+    Button(onClick = onPick, enabled = !importing) {
+        Text(if (importing) "Importing..." else "Pick GPX")
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/ui/import/ImportViewModel.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/import/ImportViewModel.kt
@@ -1,0 +1,31 @@
+package com.mebeatme.android.ui.import
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mebeatme.android.data.import.FileImportCoordinator
+import com.mebeatme.android.data.persistence.RunStore
+import com.mebeatme.android.domain.AnalysisService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class ImportViewModel(
+    private val coordinator: FileImportCoordinator,
+    private val analysis: AnalysisService,
+    private val store: RunStore
+) : ViewModel() {
+    private val _importing = MutableStateFlow(false)
+    val importing: StateFlow<Boolean> = _importing
+
+    fun onPickGpx(uri: Uri, resolver: ContentResolver) {
+        viewModelScope.launch {
+            _importing.value = true
+            val run = coordinator.import(uri, resolver)
+            val (analyzed, _) = analysis.analyze(run)
+            store.save(analyzed)
+            _importing.value = false
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/ui/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/settings/SettingsScreen.kt
@@ -1,0 +1,12 @@
+package com.mebeatme.android.ui.settings
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+
+@Composable
+fun SettingsScreen(viewModel: SettingsViewModel) {
+    val window by viewModel.windowSec.collectAsState()
+    Text("Window: ${window / 604800} weeks")
+}

--- a/androidApp/src/main/java/com/mebeatme/android/ui/settings/SettingsViewModel.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,10 @@
+package com.mebeatme.android.ui.settings
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class SettingsViewModel : ViewModel() {
+    private val _windowSec = MutableStateFlow(60 * 60 * 24 * 7 * 8)
+    val windowSec: StateFlow<Int> = _windowSec
+}

--- a/androidApp/src/main/java/com/mebeatme/android/util/DateExt.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/util/DateExt.kt
@@ -1,0 +1,6 @@
+package com.mebeatme.android.util
+
+fun Long.isWithinDays(days: Int, now: Long = System.currentTimeMillis()): Boolean {
+    val window = now - days * 24 * 60 * 60 * 1000L
+    return this >= window
+}

--- a/androidApp/src/main/java/com/mebeatme/android/util/Files.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/util/Files.kt
@@ -1,0 +1,12 @@
+package com.mebeatme.android.util
+
+import java.io.File
+
+object Files {
+    fun atomicWrite(target: File, content: String) {
+        val tmp = File(target.parentFile, target.name + ".tmp")
+        tmp.writeText(content)
+        if (target.exists()) target.delete()
+        tmp.renameTo(target)
+    }
+}

--- a/androidApp/src/main/java/com/mebeatme/android/util/Logging.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/util/Logging.kt
@@ -1,0 +1,7 @@
+package com.mebeatme.android.util
+
+import android.util.Log
+
+object Logging {
+    fun d(tag: String, msg: String) = Log.d(tag, msg)
+}

--- a/androidApp/src/main/java/com/mebeatme/android/util/Units.kt
+++ b/androidApp/src/main/java/com/mebeatme/android/util/Units.kt
@@ -1,0 +1,10 @@
+package com.mebeatme.android.util
+
+object Units {
+    fun metersPerSecondToSecPerKm(mps: Double): Double = if (mps == 0.0) 0.0 else 1000.0 / mps
+    fun secPerKmToMetersPerSecond(sec: Double): Double = if (sec == 0.0) 0.0 else 1000.0 / sec
+    fun secPerKmToMinPerKm(sec: Double): Double = sec / 60.0
+    fun minPerKmToSecPerKm(min: Double): Double = min * 60.0
+    fun mpsToMinPerKm(mps: Double): Double = secPerKmToMinPerKm(metersPerSecondToSecPerKm(mps))
+    fun minPerKmToMps(min: Double): Double = secPerKmToMetersPerSecond(minPerKmToSecPerKm(min))
+}

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">MeBeatMe</string>
+</resources>

--- a/androidApp/src/test/java/com/mebeatme/android/GPXParserTest.kt
+++ b/androidApp/src/test/java/com/mebeatme/android/GPXParserTest.kt
@@ -1,0 +1,18 @@
+package com.mebeatme.android
+
+import com.mebeatme.android.data.import.parsers.GPXParser
+import org.junit.Test
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+
+class GPXParserTest {
+    @Test
+    fun parseSample() {
+        val parser = GPXParser()
+        val input = File("src/test/java/com/mebeatme/android/sample_5k.gpx").inputStream()
+        val run = parser.parse(input)
+        assertTrue(run.distanceMeters > 800.0 && run.distanceMeters < 1200.0)
+        assertEquals(1800, run.elapsedSeconds, 5)
+    }
+}

--- a/androidApp/src/test/java/com/mebeatme/android/KmpBridgeTest.kt
+++ b/androidApp/src/test/java/com/mebeatme/android/KmpBridgeTest.kt
@@ -1,0 +1,22 @@
+package com.mebeatme.android
+
+import com.mebeatme.android.domain.PerfIndex
+import com.mebeatme.shared.core.PurdyPointsCalculator
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class KmpBridgeTest {
+    @Test
+    fun purdyMatchesShared() {
+        val expected = PurdyPointsCalculator.calculatePPI(5000.0, 1500)
+        val actual = PerfIndex.purdyScore(5000.0, 1500)
+        assertEquals(expected, actual, 0.0001)
+    }
+
+    @Test
+    fun targetPaceMatchesShared() {
+        val expected = PurdyPointsCalculator.calculateRequiredPace(5000.0, 1000.0)
+        val actual = PerfIndex.targetPace(5000.0, 3600)
+        assertEquals(expected, actual, 0.0001)
+    }
+}

--- a/androidApp/src/test/java/com/mebeatme/android/RunStoreTest.kt
+++ b/androidApp/src/test/java/com/mebeatme/android/RunStoreTest.kt
@@ -1,0 +1,23 @@
+package com.mebeatme.android
+
+import com.mebeatme.android.data.persistence.JsonRunStore
+import com.mebeatme.android.models.RunRecord
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.io.File
+import org.junit.Assert.assertEquals
+
+class RunStoreTest {
+    @Test
+    fun highestPpiInWindow() = runBlocking {
+        val file = File.createTempFile("runs", ".json")
+        val store = JsonRunStore(file)
+        val now = System.currentTimeMillis()
+        val day = 24 * 60 * 60 * 1000L
+        store.save(RunRecord("1", "GPX", now - day, now - day + 1000, 1000.0, 400, 400.0, ppi = 48.2))
+        store.save(RunRecord("2", "GPX", now - 10 * day, now - 10 * day + 1000, 1000.0, 390, 390.0, ppi = 51.9))
+        store.save(RunRecord("3", "GPX", now - 91 * day, now - 91 * day + 1000, 1000.0, 390, 390.0, ppi = 49.7))
+        val bests = store.bests(now)
+        assertEquals(51.9, bests.highestPPILast90Days)
+    }
+}

--- a/androidApp/src/test/java/com/mebeatme/android/UnitsTest.kt
+++ b/androidApp/src/test/java/com/mebeatme/android/UnitsTest.kt
@@ -1,0 +1,15 @@
+package com.mebeatme.android
+
+import com.mebeatme.android.util.Units
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class UnitsTest {
+    @Test
+    fun conversionRoundTrip() {
+        val mps = 3.0
+        val min = Units.mpsToMinPerKm(mps)
+        val back = Units.minPerKmToMps(min)
+        assertEquals(mps, back, 1e-6)
+    }
+}

--- a/androidApp/src/test/java/com/mebeatme/android/sample_5k.gpx
+++ b/androidApp/src/test/java/com/mebeatme/android/sample_5k.gpx
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="MeBeatMe Test" xmlns="http://www.topografix.com/GPX/1/1">
+  <metadata>
+    <name>Sample 5K Run</name>
+    <desc>Test run for 5K distance</desc>
+    <time>2024-01-15T08:00:00Z</time>
+  </metadata>
+  <trk>
+    <name>5K Training Run</name>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194">
+        <time>2024-01-15T08:00:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7759" lon="-122.4204">
+        <time>2024-01-15T08:05:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7769" lon="-122.4214">
+        <time>2024-01-15T08:10:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7779" lon="-122.4224">
+        <time>2024-01-15T08:15:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7789" lon="-122.4234">
+        <time>2024-01-15T08:20:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7799" lon="-122.4244">
+        <time>2024-01-15T08:25:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7809" lon="-122.4254">
+        <time>2024-01-15T08:30:00Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     kotlin("js") version "2.0.0" apply false
     kotlin("jvm") version "2.0.0" apply false
     id("com.android.library") version "8.2.0" apply false
+    id("com.android.application") version "8.2.0" apply false
 }
 
 allprojects {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,4 +7,4 @@ pluginManagement {
 }
 
 rootProject.name = "MeBeatMe"
-include(":core", ":platform:wearos", ":platform:watchos", ":web", ":server")
+include(":core", ":platform:wearos", ":platform:watchos", ":web", ":server", ":shared", ":androidApp", ":wearApp")

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.mebeatme.wear"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.mebeatme.wear"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.1"
+    }
+    buildFeatures { compose = true }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.3" }
+}
+
+dependencies {
+    implementation(project(":shared"))
+    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.activity:activity-compose:1.7.2")
+}

--- a/wearApp/src/main/AndroidManifest.xml
+++ b/wearApp/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mebeatme.wear">
+    <application android:label="MeBeatMe Wear">
+        <activity android:name="com.mebeatme.wear.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/wearApp/src/main/java/com/mebeatme/wear/MainActivity.kt
+++ b/wearApp/src/main/java/com/mebeatme/wear/MainActivity.kt
@@ -1,0 +1,22 @@
+package com.mebeatme.wear
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import com.mebeatme.wear.ui.home.WearHomeScreen
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { App() }
+    }
+}
+
+@Composable
+fun App() {
+    MaterialTheme {
+        WearHomeScreen(null)
+    }
+}

--- a/wearApp/src/main/java/com/mebeatme/wear/ui/home/WearHomeScreen.kt
+++ b/wearApp/src/main/java/com/mebeatme/wear/ui/home/WearHomeScreen.kt
@@ -1,0 +1,9 @@
+package com.mebeatme.wear.ui.home
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun WearHomeScreen(highestPpi: Double?) {
+    Text("Highest PPI (90d): ${highestPpi ?: "--"}")
+}


### PR DESCRIPTION
## Summary
- introduce `androidApp` module with Compose UI scaffolding
- parse GPX files and calculate Purdy performance index via shared module
- persist runs to JSON store and expose 90‑day best PPI API
- add minimal `wearApp` stub

## Testing
- `./gradlew :androidApp:test` *(fails: Unable to tunnel through proxy - HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bea6fa72f8832192e9dda44aa7e2a1